### PR TITLE
Send template

### DIFF
--- a/code/MandrillEmail.php
+++ b/code/MandrillEmail.php
@@ -143,6 +143,46 @@ class MandrillEmail extends Email
     }
 
     /**
+     * Basic functionality to allow sending of emails using templates up in Mandrill by using the
+     * sendTemplate function of the Messages class in the mailer.
+     * @param  string templateName the name of the template in mandril.
+     * @param  array globalMergeVars
+     * @param  string $messageID Optional message ID so the message can be identified in bounces etc.
+     * @return bool Success result of the sending operation.
+     */
+    public function sendTemplate($templateName, $globalMergeVars=null, $messageID = null)
+    {
+        // @TODO allow non-global merge vars and possibly impliment other features of sendTemplate.
+
+        // Do some checks that required things are set.
+        if (!$templateName) {
+            throw new Exception('You must set a template');
+        }
+
+        if (!$this->subject) {
+            throw new Exception('You must set a subject');
+        }
+
+        $this->from = MandrillMailer::resolveDefaultFromEmail($this->from);
+        if (!$this->from) {
+            throw new Exception('You must set a sender');
+        }
+
+        if ($this->to_member && !$this->to) {
+            // Include name in to as standard rfc
+            $this->to = $this->to_member->FirstName.' '.$this->to_member->Surname.' <'.$this->to_member->Email.'>';
+        }
+        $this->to = MandrillMailer::resolveDefaultToEmail($this->to);
+        if (!$this->to) {
+            throw new Exception('You must set a recipient');
+        }
+
+        // Need to call the sendTemplate function in the mailer which in turn calls
+        // the mandrill->messages->sendTemplate() to make the sendTemplate API call.
+        return self::mailer()->sendTemplate($templateName, $globalMergeVars, $this->to, $this->from, $this->subject, $this->customHeaders);
+    }
+
+    /**
      * Is body parsed or not?
      *
      * @return bool
@@ -154,7 +194,7 @@ class MandrillEmail extends Email
 
     /**
      * Set if body should be parsed or not
-     * 
+     *
      * @param bool $v
      * @return \MandrillEmail
      */
@@ -417,7 +457,7 @@ class MandrillEmail extends Email
 
     /**
      * Get rendered body
-     * 
+     *
      * @return string
      */
     public function getRenderedBody()
@@ -428,7 +468,7 @@ class MandrillEmail extends Email
 
     /**
      * Set image in the body of the message - see BasicEmail.ss
-     * 
+     *
      * @param Image|int $image Image or ImageID
      * @param int $size
      */
@@ -487,7 +527,7 @@ class MandrillEmail extends Email
     }
 
     /**
-     * 
+     *
      * @return string
      */
     public function getTheme()
@@ -533,7 +573,7 @@ class MandrillEmail extends Email
 
     /**
      * Set theme variables - see getTheme for available options
-     * 
+     *
      * @param array $vars
      */
     public function setThemeOptions($vars)
@@ -613,7 +653,7 @@ class MandrillEmail extends Email
 
     /**
      * Get recipient as member
-     * 
+     *
      * @return Member
      */
     public function getToMember()
@@ -630,7 +670,7 @@ class MandrillEmail extends Email
 
     /**
      * Set recipient
-     * 
+     *
      * @param string $val
      * @return Email
      */
@@ -677,7 +717,7 @@ class MandrillEmail extends Email
 
     /**
      * Set current member as recipient
-     * 
+     *
      * @return MandrillEmail
      */
     public function setToCurrentMember()
@@ -707,7 +747,7 @@ class MandrillEmail extends Email
 
     /**
      * Set From Member
-     * 
+     *
      * @param Member $member
      * @return MandrillEmail
      */
@@ -720,7 +760,7 @@ class MandrillEmail extends Email
 
     /**
      * Get custom api params for this message.
-     * 
+     *
      * @return array
      */
     public function getApiParams()

--- a/code/MandrillMailer.php
+++ b/code/MandrillMailer.php
@@ -632,10 +632,20 @@ class MandrillMailer extends Mailer
             $params['from_name'] = $fromName;
         }
 
-        // If merge vars specified then include.
-        // @TODO probablly need to allow non-global merge vars as well.
+        // If merge vars specified then include them.
         if ($globalMergeVars) {
-            $params['global_merge_vars'] = array($globalMergeVars);
+
+            // Need to convert to the correct format for sending via the api.
+            $mergeVars = array();
+
+            foreach($globalMergeVars as $key => $val) {
+                $mergeVars[] = array(
+                    'name' => $key,
+                    'content' => $val
+                );
+            }
+
+            $params['global_merge_vars'] = $mergeVars;
         }
 
         // Inject additional params into message

--- a/code/MandrillMailer.php
+++ b/code/MandrillMailer.php
@@ -586,12 +586,12 @@ class MandrillMailer extends Mailer
     /**
      * Sends emails using specified template in mandrill.
      * Note: not all parameters and features of mandrill->messages->sendTemplate are implimented.
-     * @param  string templateName The name of the template in mandrill.
-     * @param  array globalMergeVars associative array of merge vars.
-     * @param  string to email address to send the message.
-     * @param  string from the email address the message is from.
-     * @param  string subject subject of the email.
-     * @param  array customheaders custom headers to add to the request.
+     * @param  string $templateName The name of the template in mandrill.
+     * @param  array $globalMergeVars associative array of merge vars.
+     * @param  string $to email address to send the message.
+     * @param  string $from the email address the message is from.
+     * @param  string $subject subject of the email.
+     * @param  array $customheaders custom headers to add to the request.
      * @return bool success indicates result to sending the message to mantrill.
      */
     public function sendTemplate($templateName, $globalMergeVars, $to, $from, $subject, $customheaders)
@@ -621,12 +621,14 @@ class MandrillMailer extends Mailer
         }
 
         // Put together the parameters.
-        $params = array_merge($default_params,
+        $params = array_merge(
+            $default_params,
             array(
-            "subject" => $subject,
-            "from_email" => $fromEmail,
-            "to" => $to_array
-        ));
+                "subject" => $subject,
+                "from_email" => $fromEmail,
+                "to" => $to_array
+            )
+        );
 
         if ($fromName) {
             $params['from_name'] = $fromName;


### PR DESCRIPTION
Added send template functionality which allows emails to be sent using templates up in the Mandrill site. The core mandrill supports this but was not implimented in the silverstripe module.
